### PR TITLE
Add algernon (support request)

### DIFF
--- a/community/algernon/BUILD
+++ b/community/algernon/BUILD
@@ -1,0 +1,18 @@
+pkgname=algernon
+pkgver=1.9
+pkgdesc='Web server with built-in support for QUIC, HTTP/2, Lua, Markdown and Pongo2'
+license=(MIT)
+
+prepare() {
+  export GOPATH="$srcdir"
+  go get -d github.com/xyproto/algernon
+  cd "$srcdir"/src/github.com/xyproto/algernon && git checkout "$pkgver"
+}
+
+build() {
+  cd "$srcdir"/src/github.com/xyproto/algernon && go build
+}
+
+package() {
+  install -D "$srcdir"/src/github.com/xyproto/algernon -t "$pkgdir"/bin/
+}


### PR DESCRIPTION
Added a package for a small and self-contained web server that I wrote in Go.

The BUILD file needs testing, what's the easiest way to test it after launching the docker image with:

    docker run -it mesalocklinux/mesalock-linux

?